### PR TITLE
KAIZEN-0 Øke default CPU og threshold

### DIFF
--- a/app-config.yaml
+++ b/app-config.yaml
@@ -2,8 +2,7 @@
 image: docker.adeo.no:5000/fo/modiaeventdistribution
 replicas:
   min: 4
-  max: 8
-  cpuThresholdPercentage: 25
+  max: 6
 port: 8080
 healthcheck:
   liveness:
@@ -16,6 +15,8 @@ prometheus:
   enabled: true
   path: modiaeventdistribution/internal/metrics
 resources:
+  requests:
+    cpu: 500m
   limits:
     cpu: 3
 fasitResources:


### PR DESCRIPTION
med 25% som trigger for autoscaling og såpass lav request for CPU ligger
applikasjonen nært opp mot behov for auto-scaling hele tiden. Endrer disse
for å redusere behovet for auto-scaling. Da det ikke er ønskelig at vi drar
opp og ned nodene hele tiden. (websocket er litt statefull)