### PR TITLE
KAIZEN-0 Fiks syntaksfeil i app-config

### DIFF
--- a/app-config.yaml
+++ b/app-config.yaml
@@ -31,9 +31,10 @@ fasitResources:
   - alias: srvmodiaeventdistribution
     resourceType: credential
   - alias: veilarblogin.redirect-url
-      resourceType: restservice
-      propertyMap:
-        url: OIDC_REDIRECT_URL
+    resourceType: restservice
+    propertyMap:
+      url: OIDC_REDIRECT_URL
+
   exposed:
   - alias: modiaeventdistribution-isalive
     resourceType: restservice


### PR DESCRIPTION
Får ikke deployet til q6 pga. indenteringsfeil i app-config.yaml